### PR TITLE
support osx

### DIFF
--- a/src/aarch64.s
+++ b/src/aarch64.s
@@ -31,8 +31,7 @@ fiber_restore_ret_raw:
 
 # fiber_enter: fn(usize, fn(usize) -> usize)
 # Enter a fresh stack and call the supplied function
-.global fiber_enter
-fiber_enter:
+.macro FIBER_ENTER_IMPL
     mov x9, lr
     bl  fiber_save_raw
     # Switch stack and enter
@@ -44,10 +43,10 @@ fiber_enter:
     mov sp, x0
     mov x1, 1
     b   fiber_restore_ret_raw
+.endm
 
 # fiber_switch: fn(usize) -> usize
-.global fiber_switch
-fiber_switch:
+.macro FIBER_SWITCH_IMPL
     mov x9, lr
     bl  fiber_save_raw
     # Switch stack
@@ -56,3 +55,20 @@ fiber_switch:
     mov x0, x9
     mov x1, 0
     b   fiber_restore_ret_raw
+.endm
+
+.global fiber_enter
+fiber_enter:
+    FIBER_ENTER_IMPL
+
+.global _fiber_enter
+_fiber_enter:
+    FIBER_ENTER_IMPL
+
+.global fiber_switch
+fiber_switch:
+    FIBER_SWITCH_IMPL
+
+.global _fiber_switch
+_fiber_switch:
+    FIBER_SWITCH_IMPL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl Stack {
                 ptr::null_mut(),
                 0x200000,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_STACK,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
                 -1,
                 0,
             );

--- a/src/x86_64.s
+++ b/src/x86_64.s
@@ -30,8 +30,7 @@ fiber_restore_ret_raw:
 
 # fiber_enter: fn(usize, fn(usize) -> usize)
 # Enter a fresh stack and call the supplied function
-.global fiber_enter
-fiber_enter:
+.macro FIBER_ENTER_IMPL
     call fiber_save_raw
     # Switch stack and enter
     xchg rsp, rdi
@@ -40,13 +39,30 @@ fiber_enter:
     mov rsp, rax
     mov rdx, 1
     jmp fiber_restore_ret_raw
+.endm
 
 # fiber_switch: fn(usize) -> usize
-.global fiber_switch
-fiber_switch:
+.macro FIBER_SWITCH_IMPL
     call fiber_save_raw
     # Switch stack
     mov rax, rsp
     mov rsp, rdi
     mov rdx, 0
     jmp fiber_restore_ret_raw
+.endm
+
+.global fiber_enter
+fiber_enter:
+    FIBER_ENTER_IMPL
+
+.global _fiber_enter
+_fiber_enter:
+    FIBER_ENTER_IMPL
+
+.global fiber_switch
+fiber_switch:
+    FIBER_SWITCH_IMPL
+
+.global _fiber_switch
+_fiber_switch:
+    FIBER_SWITCH_IMPL


### PR DESCRIPTION
The PR is tested in linux/x86_64, and osx by `cargo test` and `cargo run --example read`. 
1. remove libc::MAP_STACK, which is not defined in osx, and is no-op in linux, see [mmap(2) in linux](https://man7.org/linux/man-pages/man2/mmap.2.html) and [mmap(2) in osx](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/mmap.2.html)
2. *.s support osx